### PR TITLE
fix: change gh-pages action to publish on push to main

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Publish to gh-pages
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/development' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         with:
           publish_branch: gh-pages  # default: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The documentation action currently only publishes on pushes to ‘development’. This pull request will instead allow documentation to be published whenever a push to ‘main’ occurs.